### PR TITLE
Few features for longer and dynamic tests

### DIFF
--- a/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTPublisherGui.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTPublisherGui.java
@@ -73,7 +73,7 @@ public class MQTTPublisherGui extends AbstractSamplerGui implements ChangeListen
     private final JLabeledTextField mqttKeepAlive = new JLabeledTextField(Constants.MQTT_KEEP_ALIVE);
 
     private final JLabeledTextField mqttUser = new JLabeledTextField(Constants.MQTT_USERNAME);
-    private final JLabeledTextField mqttPwd = new JLabeledPasswordField(Constants.MQTT_PASSWORD);
+    private final JLabeledTextField mqttPwd = new JLabeledTextField(Constants.MQTT_PASSWORD);
     private final JButton resetUserNameAndPassword = new JButton(Constants.MQTT_RESET_USERNAME_PASSWORD);
 
     private final JLabeledRadioI18N typeQoSValue = new JLabeledRadioI18N(Constants.MQTT_QOS, QOS_TYPES_ITEMS, Constants.MQTT_AT_MOST_ONCE);
@@ -229,6 +229,7 @@ public class MQTTPublisherGui extends AbstractSamplerGui implements ChangeListen
         panel.add(Box.createHorizontalStrut(10));
         panel.add(mqttUser);
         panel.add(Box.createHorizontalStrut(10));
+        mqttPwd.setText("enter a password");
         panel.add(mqttPwd);
         panel.add(Box.createHorizontalStrut(10));
         panel.add(resetUserNameAndPassword);

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTSubscriberGui.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTSubscriberGui.java
@@ -38,6 +38,9 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * This is the MQTT Sibscriber Sampler GUI class. All swing components of the UI are included in this class.
@@ -57,6 +60,8 @@ public class MQTTSubscriberGui extends AbstractSamplerGui implements ActionListe
     private final JLabeledTextField mqttDestination = new JLabeledTextField(Constants.MQTT_TOPIC);
 
     private final JCheckBox cleanSession = new JCheckBox(Constants.MQTT_CLEAN_SESSION, false);
+    private final JCheckBox listenOnAnotherThread = new JCheckBox(Constants.LISTEN_ON_THREAD, false);
+    private final JLabeledTextField threadTimeout = new JLabeledTextField(Constants.THREAD_TIMEOUT);
 
     private final JLabeledTextField mqttKeepAlive = new JLabeledTextField(Constants.MQTT_KEEP_ALIVE);
 
@@ -112,6 +117,8 @@ public class MQTTSubscriberGui extends AbstractSamplerGui implements ActionListe
         sampler.setClientId(clientId.getText());
         sampler.setTopicName(mqttDestination.getText());
         sampler.setCleanSession(cleanSession.isSelected());
+        sampler.setNewThread(listenOnAnotherThread.isSelected());
+        sampler.setThreadTimeOut(threadTimeout.getText());
         sampler.setKeepAlive(mqttKeepAlive.getText());
         sampler.setUsername(mqttUser.getText());
         sampler.setPassword(mqttPwd.getText());
@@ -139,6 +146,8 @@ public class MQTTSubscriberGui extends AbstractSamplerGui implements ActionListe
         ControlPanel.add(DPanel);
         ControlPanel.add(createDestinationPane());
         ControlPanel.add(cleanSession);
+        ControlPanel.add(listenOnAnotherThread);
+        ControlPanel.add(threadTimeout);
         ControlPanel.add(createKeepAlivePane());
         ControlPanel.add(createAuthPane());
         ControlPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createLineBorder(Color.gray),
@@ -193,6 +202,8 @@ public class MQTTSubscriberGui extends AbstractSamplerGui implements ActionListe
         clientId.setText(sampler.getClientId());
         mqttDestination.setText(sampler.getTopicName());
         cleanSession.setSelected(sampler.isCleanSession());
+        listenOnAnotherThread.setSelected(sampler.isNewThread());
+        threadTimeout.setText(sampler.getThreadTimeout());
         mqttKeepAlive.setText(Integer.toString(sampler.getKeepAlive()));
         mqttUser.setText(sampler.getUsername());
         mqttPwd.setText(sampler.getPassword());

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTSubscriberGui.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/control/gui/MQTTSubscriberGui.java
@@ -61,7 +61,7 @@ public class MQTTSubscriberGui extends AbstractSamplerGui implements ActionListe
     private final JLabeledTextField mqttKeepAlive = new JLabeledTextField(Constants.MQTT_KEEP_ALIVE);
 
     private final JLabeledTextField mqttUser = new JLabeledTextField(Constants.MQTT_USERNAME);
-    private final JLabeledTextField mqttPwd = new JLabeledPasswordField(Constants.MQTT_PASSWORD);
+    private final JLabeledTextField mqttPwd = new JLabeledTextField(Constants.MQTT_PASSWORD);
     private final JButton resetUserNameAndPassword = new JButton(Constants.MQTT_RESET_USERNAME_PASSWORD);
 
     private final JLabeledRadioI18N typeQoSValue = new JLabeledRadioI18N(Constants.MQTT_QOS, QOS_TYPES_ITEMS, Constants.MQTT_AT_MOST_ONCE);

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/paho/clients/AsyncClient.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/paho/clients/AsyncClient.java
@@ -215,7 +215,7 @@ public class AsyncClient extends BaseClient {
      */
     @Override
     public boolean isConnected() {
-        return client.isConnected();
+        return client != null && client.isConnected();
     }
 
     /**
@@ -224,7 +224,9 @@ public class AsyncClient extends BaseClient {
     @Override
     public void close() throws IOException {
         try {
-            client.disconnect();
+            if (client != null && client.isConnected()) {
+                client.disconnect();
+            }
         } catch (MqttException e) {
             e.printStackTrace();
             log.error(e.getMessage(), e);

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/paho/clients/BlockingClient.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/paho/clients/BlockingClient.java
@@ -181,7 +181,9 @@ public class BlockingClient extends BaseClient {
     @Override
     public void close() throws IOException{
         try {
-            client.disconnect();
+            if (client != null && client.isConnected()) {
+                client.disconnect();
+            }
         } catch (MqttException e) {
             throw new IOException(e.getMessage(), e);
         }

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/PublisherSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/PublisherSampler.java
@@ -254,12 +254,17 @@ public class PublisherSampler extends AbstractSampler implements TestStateListen
             } else if (Constants.MQTT_MESSAGE_INPUT_TYPE_FILE.equals(messageInputType)) {
                 publishMessage = FileUtils.readFileToByteArray(new File(getMessageValue()));
             }
-            
+            if (null != client) {
+                //make sure this client is closed before making a new connection
+                client.close();
+            }
+
             if (Constants.MQTT_BLOCKING_CLIENT.equals(clientType)) {
                 client = new BlockingClient(brokerURL, clientId, isCleanSession, userName, password, keepAlive);
             } else if (Constants.MQTT_ASYNC_CLIENT.equals(clientType)) {
                 client = new AsyncClient(brokerURL, clientId, isCleanSession, userName, password, keepAlive);
             }
+
             
             if (null != client) {
                 ClientPool.addClient(client);

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/SubscriberSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/SubscriberSampler.java
@@ -56,6 +56,8 @@ public class SubscriberSampler extends AbstractSampler implements Interruptible,
     private static final String CLIENT_ID = "mqtt.client.id";
     private static final String TOPIC_NAME = "mqtt.topic.name";
     private static final String CLEAN_SESSION = "mqtt.clean.session";
+    private static final String NEW_THREAD = "mqtt.new.thread";
+    private static final String THREAD_TIMEOUT = "mqtt.thread.timeout";
     private static final String KEEP_ALIVE = "mqtt.keep.alive";
     private static final String USERNAME = "mqtt.auth.username";
     private static final String PASSWORD = "mqtt.auth.password.subscriber";
@@ -78,6 +80,12 @@ public class SubscriberSampler extends AbstractSampler implements Interruptible,
     public boolean isCleanSession() {
         return getPropertyAsBoolean(CLEAN_SESSION);
     }
+
+    public boolean isNewThread() {
+        return getPropertyAsBoolean(NEW_THREAD);
+    }
+
+    public String getThreadTimeout() {return getPropertyAsString(THREAD_TIMEOUT);}
 
     public int getKeepAlive() {
         return getPropertyAsInt(KEEP_ALIVE);
@@ -119,6 +127,12 @@ public class SubscriberSampler extends AbstractSampler implements Interruptible,
     public void setCleanSession(boolean isCleanSession) {
         setProperty(CLEAN_SESSION, isCleanSession);
     }
+
+    public void setNewThread(boolean isNewThread){
+        setProperty(NEW_THREAD, isNewThread);
+    }
+
+    public void setThreadTimeOut(String threadTimeOut) {setProperty(THREAD_TIMEOUT, threadTimeOut);}
 
     public void setKeepAlive(String keepAlive) {setProperty(KEEP_ALIVE, keepAlive);}
 
@@ -332,12 +346,106 @@ public class SubscriberSampler extends AbstractSampler implements Interruptible,
                 result.setResponseCodeOK();
                 return result;
             }
+
+            if (isNewThread()) {
+                long timeout;
+                try {
+                    timeout = Integer.valueOf(getThreadTimeout());
+                } catch (NumberFormatException e) {
+                    timeout = 0;
+                }
+                if (timeout > 0) {
+                    final long finalTimeout = timeout;
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            reciveMessages(result, true, finalTimeout);
+                        }
+                    }).start();
+
+                    result.setSuccessful(true);
+                    result.setResponseMessage("Subscriber started on another thread check log for actual value.");
+                    result.sampleEnd();
+                    result.setResponseCodeOK();
+                    return result;
+                } else {
+
+                    return reciveMessages(result, false, 0);
+                }
+            }
         }
 
         result.setSuccessful(false);
-        result.setResponseMessage("Client has been stopped or an error occurred while receiving messages. Received "  + " valid messages.");
+        result.setResponseMessage("Client has been stopped or an error occurred while receiving messages. Received "
+                + " valid messages.");
         result.sampleEnd();
         result.setResponseCode("FAILED");
+        return result;
+    }
+
+    private boolean timeoutDidNotPass(long start, long timeout, boolean checkTimeOut) {
+        if (checkTimeOut) {
+            long currTime = System.currentTimeMillis();
+            if (currTime - start > timeout) {
+               return false;
+            }
+        }
+        return true;
+    }
+
+    private SampleResult reciveMessages(SampleResult result, boolean onAnotherThread, long timeout) {
+        Message receivedMessage;
+        long startTime = System.currentTimeMillis();
+        long timeoutMili = timeout * 1000;
+        boolean checkTimeOut = timeout > 0;
+        while (timeoutDidNotPass(startTime, timeoutMili, checkTimeOut) && !interrupted && null != client.getReceivedMessages() && null != client.getReceivedMessageCounter()) {
+            receivedMessage = client.getReceivedMessages().poll();
+            if (receivedMessage != null) {
+                if (onAnotherThread){
+                    log.info(lineSeparator + "Received " + client.getReceivedMessageCounter().get() + " " +
+                            "messages." +
+                            lineSeparator + "Current message QOS : " + receivedMessage.getQos() +
+                            lineSeparator + "Is current message a duplicate : " + receivedMessage.isDup()
+                            + lineSeparator + "Received timestamp of current message : " +
+                            receivedMessage.getCurrentTimestamp() + lineSeparator + "Is current message" +
+                            " a retained message : " + receivedMessage.isRetained());
+                }
+                else {
+                    client.getReceivedMessageCounter().incrementAndGet();
+                    result.sampleEnd();
+                    result.setSuccessful(true);
+                    result.setResponseMessage(lineSeparator + "Received " + client.getReceivedMessageCounter().get() + " " +
+                            "messages." +
+                            lineSeparator + "Current message QOS : " + receivedMessage.getQos() +
+                            lineSeparator + "Is current message a duplicate : " + receivedMessage.isDup()
+                            + lineSeparator + "Received timestamp of current message : " +
+                            receivedMessage.getCurrentTimestamp() + lineSeparator + "Is current message" +
+                            " a retained message : " + receivedMessage.isRetained());
+                    result.setBytes(receivedMessage.getPayload().length);
+                    result.setResponseData(receivedMessage.getPayload());
+                    result.setResponseCodeOK();
+                    return result;
+                }
+            }
+        }
+        if (onAnotherThread) {
+            if (!timeoutDidNotPass(startTime, timeoutMili, checkTimeOut) && client != null) {
+                try {
+                    client.disconnect();
+                } catch (MqttException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                log.error("Client has been stopped or an error occurred while receiving messages. Received valid messages.");
+            }
+        }
+        else {
+            result.setSuccessful(false);
+            result.setResponseMessage("Client has been stopped or an error occurred while receiving messages. Received "
+                    + " valid messages.");
+            result.sampleEnd();
+            result.setResponseCode("FAILED");
+        }
         return result;
     }
 

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/SubscriberSampler.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/sampler/SubscriberSampler.java
@@ -58,7 +58,7 @@ public class SubscriberSampler extends AbstractSampler implements Interruptible,
     private static final String CLEAN_SESSION = "mqtt.clean.session";
     private static final String KEEP_ALIVE = "mqtt.keep.alive";
     private static final String USERNAME = "mqtt.auth.username";
-    private static final String PASSWORD = "mqtt.auth.password";
+    private static final String PASSWORD = "mqtt.auth.password.subscriber";
     private static final String QOS = "mqtt.qos";
     private static final String CLIENT_TYPE = "mqtt.client.type";
 

--- a/src/main/java/org/apache/jmeter/protocol/mqtt/utilities/Constants.java
+++ b/src/main/java/org/apache/jmeter/protocol/mqtt/utilities/Constants.java
@@ -50,4 +50,6 @@ public final class Constants {
     public static final String MQTT_USER_USERNAME = "admin";
     public static final String MQTT_USERNAME = "Username";
     public static final String RESET_CREDENTIALS = "reset_credentials";
+    public static final String LISTEN_ON_THREAD =  "Listen on Thread";
+    public static final String THREAD_TIMEOUT = "Thread Timeout";
 }


### PR DESCRIPTION
Hi,
this PR contains few changes that would enable to run load tests using this plugin dynamically (changed the password fields to be textField instead of password field),
and also changed the subscriber to connect only when the sampler starts so we could inject data received from other samplers.
one more thing is that I added the option to run the subscriber on a different thread so it won't stop the test from running while listening.
Thanks,
Ariel